### PR TITLE
Fix. rise error when receive untagged response with one token.

### DIFF
--- a/imap4.lua
+++ b/imap4.lua
@@ -233,6 +233,7 @@ function IMAP:_do_cmd(cmd, ...)
 			token, args = args:match('^(%S+)%s*(.*)$')
 			args = n .. ' ' .. args
 		end
+		if not token then token = blocks[i] end
 		local t = res[token]
 		t[#t+1] = args
 	end


### PR DESCRIPTION
For example

```
CLI SEND: 0.001251258888515914 LOGOUT
CLI RECV: * BYE
CLI RECV: 0.001251258888515914 OK LOGOUT completed
```

In that case `* BYE` response causes error.
