### PR TITLE
Issues with whitespace at end of STATUS response w/ Exchange 2010.

### DIFF
--- a/imap4.lua
+++ b/imap4.lua
@@ -390,7 +390,7 @@ function IMAP:status(mailbox, names)
 	names = to_list(names or '(MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)')
 	local res = self:_do_cmd('STATUS %s %s', mailbox, names)
 
-	local list = to_table(assert(res.STATUS[1]:match('(%b())$'), 'Invalid response'))
+	local list = to_table(assert(res.STATUS[1]:match('(%b())%s*$'), 'Invalid response'))
 	assert(#list % 2 == 0, "Invalid response size")
 
 	local status = {}


### PR DESCRIPTION
Hi,

Ran into issues with Exchange 2010 and extraneous whitespace at end of STATUS response. I modified the match string to allow space between ()s and end of line.
